### PR TITLE
アルファ：カメラモニターアクター改良完成（仮）

### DIFF
--- a/Content/okue/0417/MonitarTest.uasset
+++ b/Content/okue/0417/MonitarTest.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:802ab9f907916bbbf90d310b3e568b43a26fc813f57572418da4e2255391e44e
+size 744916

--- a/Content/okue/0417/MonitarTest1.uasset
+++ b/Content/okue/0417/MonitarTest1.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ef202205a06860b183d0ce432197cf167566556b7dabb477c111f4a6b40376ff
+size 37367

--- a/Content/okue/0417/No-Signal.uasset
+++ b/Content/okue/0417/No-Signal.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:666840cbed519deaf4dec78ac34e24742f926a03dbb8778e96eb9a3f155eaae4
+size 15972

--- a/Content/okue/0417/No-Signal_Mat.uasset
+++ b/Content/okue/0417/No-Signal_Mat.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96636782cad49666c9f57a2dbe66a3b129086610a7eab3665c05ddd5938e33a6
+size 8672

--- a/Content/okue/0417/WB_Nosignal.uasset
+++ b/Content/okue/0417/WB_Nosignal.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06373e0638b03721866362f03f2f08e7e488ce6816f39e3d14fe9bb1e205ff53
+size 38144

--- a/Content/okue/BP/BP_CameraInput.uasset
+++ b/Content/okue/BP/BP_CameraInput.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:30f27e39c4512b60b0677fd51ef2fc31d99dcc160a540cf22b68a1579af1fd16
-size 81232
+oid sha256:07fd904601b35bb41323bfe47a433f36a7cfd785a8b0285932e1023230aadfea
+size 80219

--- a/Content/okue/BP/BP_CameraManagerTest.uasset
+++ b/Content/okue/BP/BP_CameraManagerTest.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a3f355e182789107b75ff29936beb8bd7c837682980cb41473475b83de9cdd1
+size 105791

--- a/Content/okue/BP/BP_SecurityCamera3.uasset
+++ b/Content/okue/BP/BP_SecurityCamera3.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c99fe12864f027ce649ba15aa9d833c84908a1ff55227d8c759267cee73cbe9
+size 26586

--- a/Content/okue/BP/BP_SecurityCamera4.uasset
+++ b/Content/okue/BP/BP_SecurityCamera4.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e53abda8e7b2b006e4ca54fefd31dcc17a7e9eca68a1a0cb6bb59bb5971721e6
+size 27447

--- a/Content/okue/BP/BP_SecurityCamera5.uasset
+++ b/Content/okue/BP/BP_SecurityCamera5.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7082ba81ec47235ea2952029140c7e2e3775e4197110f15933c42e6093659182
+size 25914

--- a/Content/okue/BP/BP_SecurityCamera6.uasset
+++ b/Content/okue/BP/BP_SecurityCamera6.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af6c591230c8708700abcff794c06b0c7a6ef43d9a00a98d9cf1283ef5ff1a39
+size 27447

--- a/Content/okue/BP_OkueTest.uasset
+++ b/Content/okue/BP_OkueTest.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f56c1fd7a499f1c2092cec15c172045254228199fafedb45d404aee419d81e3a
-size 311885
+oid sha256:67acdac2098fb8a7124472d2c8ec308f9ba62760cda0a524657e24559885042b
+size 289430

--- a/Content/okue/Draw2D/Camera3.uasset
+++ b/Content/okue/Draw2D/Camera3.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:868122d42a28a31e7290f21b5ed80127409038ccf2ead72e6fc75aec36df8a3e
+size 4440

--- a/Content/okue/Draw2D/Camera4.uasset
+++ b/Content/okue/Draw2D/Camera4.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f7e2d7d46357b15702555e2937c0742126c4209159f7cdd4517c1d816b1310d
+size 8602

--- a/Content/okue/Draw2D/Camera5.uasset
+++ b/Content/okue/Draw2D/Camera5.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fd0008a3d4b92b142f95d272ec6d5e9bd53ebddf94a3e7f7fc36ec213f2a1b4
+size 4049

--- a/Content/okue/Draw2D/Camera6.uasset
+++ b/Content/okue/Draw2D/Camera6.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9549c8a3b3e9685ee80c9dfaf461b86397065e9f31a437374d9abb10c83b7a8b
+size 9084

--- a/Content/okue/IMC_OkueTest.uasset
+++ b/Content/okue/IMC_OkueTest.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:643db71614975e03676ec8647838d6fc87dcfaa9e46da4b4958f3ecafdc5f662
-size 14396
+oid sha256:6da75aa593aff9823da5b44a226b251677d05f53eb7f3cbc5c139940176941ec
+size 15031

--- a/Content/okue/MT/Camera1_Mat1.uasset
+++ b/Content/okue/MT/Camera1_Mat1.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e5e332a29dbe82cb0ce1f093c2ed6152be0acc0cee42e8d122e1e36e19afe3c7
-size 10214
+oid sha256:f574055eb53a00aa4c7dae02b825336fe6885436b39a80a0a17b7d43e85bc6dd
+size 12879

--- a/Content/okue/MT/Camera1_Mat2.uasset
+++ b/Content/okue/MT/Camera1_Mat2.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37f65435c2b1a297513d6847346c3521d43c3f9c5fb4ea775899bd0b626e84d5
+size 10304

--- a/Content/okue/MT/Camera1_Mat3.uasset
+++ b/Content/okue/MT/Camera1_Mat3.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f12faa873523d586f62ee53d87c26bf208328d2fa7680f23031901b87d0c3cc
+size 11142

--- a/Content/okue/MT/Camera1_Mat4.uasset
+++ b/Content/okue/MT/Camera1_Mat4.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39943eef31e9e6e38344fe61012e205dedf31a5a01b9570af7eaaef9180b4e67
+size 11054

--- a/Content/okue/MT/Camera1_Mat5.uasset
+++ b/Content/okue/MT/Camera1_Mat5.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:484079d2b668385bc71706a40314e641a0981e0c06ae6a12aa332b4cf942a10d
+size 11532

--- a/Content/okue/MT/Camera1_Mat6.uasset
+++ b/Content/okue/MT/Camera1_Mat6.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95a9a93d95609c56d7ae057780f2443801646620e20713c476c0ff1b3d66abe3
+size 11478

--- a/Content/okue/New/WB_CameraMonitor.uasset
+++ b/Content/okue/New/WB_CameraMonitor.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:884b44b7f832027221fe6606617872450c6216c2e8faf2b7e0ce85ef8534562f
-size 57136
+oid sha256:b6a6f47bb2adb6920f2cabc86ebd4d795aa90427c07627b8f8ab692fbc0ef611
+size 56036

--- a/Content/okue/ProtoType_TestInte_okue.umap
+++ b/Content/okue/ProtoType_TestInte_okue.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0d9e369d60d4e242ca6fb80afd66243460d103add4c091cafc334be1185d3ad8
-size 856841
+oid sha256:ceb20418b30dd5d4e7c8abe23e07a2d3813aab85b59e91f3e9690e16a42a004b
+size 875405

--- a/Content/okue/WB/WB_Camera2.uasset
+++ b/Content/okue/WB/WB_Camera2.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:65c66eaac39ab728ea682dbb0d32c19881c03a8e07d9cfe7be5851c8bf16a7f2
-size 25995
+oid sha256:cb71840c587a200332b3f4c7c9c61e6487b0b20124d00cac1b8412e2ff56adb4
+size 23804


### PR DESCRIPTION
# 概要

<!-- タスクのURL。なければ次の行を削除してください -->
Notion: https://www.notion.so/1c73fc0283d1805bae03e6259bb97f7c?pvs=4

<!-- デザインのURL。なければ次の行を削除してください -->
Figma: 

<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->



# 細かな変更点
https://github.com/user-attachments/assets/265ffc35-69db-4708-a135-b2108beb5b34


https://github.com/user-attachments/assets/0ac759d7-3a54-4608-8286-3fd179686de4


<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイント -->

- インスタンス編集で変更できるようにし、描画の内容を変更するためにブラウザを開かないで済むように実装
- 何も写すものをセットしてなかったらNo-Signalと出るようにした
- No-Signalの状態ではクリックできないように作成 
- モニターに写ってるカメラに移動できるようにした
 (設定したマテリアルの判定を取ってこのマテリアルならこのカメラに移動みたいな感じで処理を実装) 



## スクリーンショット

<!-- Command + Shift + Control + 4 でスクリーンショットして Command + V でここに貼り付けるのが楽。録画動画があればなお良い。以下のテーブルは必要に応じて使ってください -->

|       | Before | After |
| :---: | :----: | :---: |
| インスタンス編集で簡単に設定できるように実装 |  | ![アルファカメラ①](https://github.com/user-attachments/assets/d079b407-f947-4f97-833d-ea4255bf26a2) |
| MonitarTestでカメラモニターを作成 |  | ![アルファカメラ②](https://github.com/user-attachments/assets/8bcc1122-93bb-4a81-a258-830d9004d519) |
| BP内の全体図 |  | ![アルファカメラ③全体的ノード](https://github.com/user-attachments/assets/197e3da2-f40e-403c-ac1e-838f3952a4a1) |
| ６つあるカメラ（画面）のメイン処理 |  | ![アルファカメラ④メイン処理](https://github.com/user-attachments/assets/13c08c5c-5dcf-46e9-8e48-18463aede1c9) |
| camera1のManagerの処理の全体図①：処理としてはマテリアルがセットされてるかを判別し、なければNo-Signalあればモニターにそのマテリアルを表示 （他のカメラも同様）|  | ![アルファカメラ⑤](https://github.com/user-attachments/assets/35e03219-857c-4149-add6-319ebd9b2745) |
| Camera1のモニターにを操作した時にセットされたマテリアルに合ったカメラに飛ぶように処理した全体図②（他のカメラも同様） |  | ![アルファカメラ⑥](https://github.com/user-attachments/assets/6eb437d7-e613-4ec8-9862-00ecc7a1979d) |
| 全体図②の拡大バージョン：ここではNo-Signal（マテリアルがセットされてない）ならモニター操作（クリック）を受付ないように処理 |  | ![アルファカメラ⑦](https://github.com/user-attachments/assets/9334f618-d537-4476-8c9a-32eac9c1a747) |
| 全体図②の拡大バージョン（下の画像が分岐一つの拡大図）：ここではcamera1にセットされたマテリアルがどれなのかを判別するように処理 |  | ![アルファカメラ⑨](https://github.com/user-attachments/assets/6555bcbf-90c4-4617-ad37-fa4c9d832446) ![アルファカメラ⑪](https://github.com/user-attachments/assets/6918aece-fae2-4912-9db2-c338f331f994)|
| 全体図②の拡大バージョン（下の画像が分岐一つの拡大図）：ここではそのマテリアルに応じたカメラにモニターを操作したらカメラが飛ぶように処理を実装※補足としてGet Actor of ClaseではBP_CameraManagerTestこのクラスをセットしていてそのクラスの処理に飛ぶようにしている |  | ![アルファカメラ⑩](https://github.com/user-attachments/assets/be8fadec-293c-4a69-a5ca-c8d07200c926) ![アルファカメラ⑫](https://github.com/user-attachments/assets/7388f3cd-be03-4076-9a27-88f553621352)|




# 影響範囲・懸念点

<!-- レビュアーに見てほしい点、影響しそうな機能 -->
カメラを新たに作成するとマテリアルも同時に作る必要があって
そのマテリアルに合ったカメラに飛ぶように都度処理を追加していかなくてはならない


# おこなった動作確認

<!-- おこなった動作確認を箇条書きで。 -->
簡単なデバック
ゲームモードOkueTestでやってた（元のMaouCameraに戻してる）


# その他

<!-- レビュアーへのメッセージや一言などあれば -->
