### PR TITLE
タイトル画面の画角調整

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -2,8 +2,8 @@
 GameName=CaseStudy
 
 [/Script/EngineSettings.GameMapsSettings]
-EditorStartupMap=/Game/CaseStudy/Yamaguchi_Alpha/Maps/TitleMap1.TitleMap1
-GameDefaultMap=/Game/CaseStudy/Yamaguchi_Alpha/Maps/TitleMap1.TitleMap1
+EditorStartupMap=/Game/CaseStudy/Hatta_UIProtOfConceptForAlpha/Maps/TitleMap_HattaEdit.TitleMap_HattaEdit
+GameDefaultMap=/Game/CaseStudy/Hatta_UIProtOfConceptForAlpha/Maps/TitleMap_HattaEdit.TitleMap_HattaEdit
 TransitionMap=
 bUseSplitscreen=True
 TwoPlayerSplitscreenLayout=Horizontal

--- a/Content/CaseStudy/Hatta_UIProtOfConceptForAlpha/Maps/TitleMap_HattaEdit.umap
+++ b/Content/CaseStudy/Hatta_UIProtOfConceptForAlpha/Maps/TitleMap_HattaEdit.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:41c917b093915a4acf2c843190865b43a531ee5280e5df8e4ef608519cdd081b
-size 881534
+oid sha256:dd3048415c133a5522e8f067e85c24e99d0845a3125d2c64df60f4ce3ccc44be
+size 882131


### PR DESCRIPTION
# 概要



# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイント -->

- Hatta_UIProtOfConceptForAlpha\Maps\TitleMap_HattaEdit.umap の画角が正しく反映されてなかったため、再度修正

## スクリーンショット

<!-- Command + Shift + Control + 4 でスクリーンショットして Command + V でここに貼り付けるのが楽。録画動画があればなお良い。以下のテーブルは必要に応じて使ってください -->

|       | Before | After |
| :---: | :----: | :---: |
| 画角調整 | ![image](https://github.com/user-attachments/assets/30ff4baa-b718-452e-a996-913694652eb4) | ![スクリーンショット (134)](https://github.com/user-attachments/assets/8d4a575b-5d6f-41fe-af12-882105144111) |


# 影響範囲・懸念点

<!-- レビュアーに見てほしい点、影響しそうな機能 -->


# おこなった動作確認

<!-- おこなった動作確認を箇条書きで。 -->
* [ プレイインエディタで画角が変わっているか確認 ] 


# その他

<!-- レビュアーへのメッセージや一言などあれば -->
