### PR TITLE
ファイルメディアソースの参照切れ修正

### DIFF
--- a/Content/CaseStudy/Hatta_UIProtOfConceptForAlpha/Movie/MP_Test.uasset
+++ b/Content/CaseStudy/Hatta_UIProtOfConceptForAlpha/Movie/MP_Test.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:40fbdf4d52220463c8ddacd6614fd06562ad28da280e0278eff304647b0c9dae
+oid sha256:6c9a66cc4eb30911e0b668f8a71894c1712cbc34d047a16a660a5f77542ff9c7
 size 1534

--- a/Content/CaseStudy/Hatta_UIProtOfConceptForAlpha/Movie/MP_Test_Video.uasset
+++ b/Content/CaseStudy/Hatta_UIProtOfConceptForAlpha/Movie/MP_Test_Video.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c80481b96d58358c8961a0da1c7bfa9a45a5caf609488c0bfba081599d88c5c8
-size 2659
+oid sha256:ef2ec9e42dade2fbe2bfbe0db82459b9d8ccbf203a5fe0fc6192d9bdeed7ad47
+size 11432

--- a/Content/CaseStudy/Yamaguchi_Alpha/UI/WBP_TutorealVideo.uasset
+++ b/Content/CaseStudy/Yamaguchi_Alpha/UI/WBP_TutorealVideo.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c46b41f04984834a569fc0efd752005857a02c3067b6e0fb189cc9930bdbcb85
-size 85024
+oid sha256:4e2f41bfe2b981fd496b4b0f09b04a697532582a4ea4a95d21ffb5c96bc05482
+size 84402

--- a/Content/Movies/Da11_2Cam_2.uasset
+++ b/Content/Movies/Da11_2Cam_2.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a1b98a17e5c0e302af4f5b1550ffecf74f3bab868f5374a7586b5f6d0fa2eea
-size 1465
+oid sha256:e51e5878011c93e519ef07011aea8465d4711381b6e3cc054ce8ca7e890e0ce4
+size 10909


### PR DESCRIPTION
# 概要


<!-- レビュアーが理解できるよう、このプルリクの概要と共に、どうしておこなったかの背景が以下に書かれているとグッド -->

チュートリアルビデオのファイルメディアソースがリダイレクタになっていたので、リダイレクタをファイルメディアソースへ修正

# 細かな変更点



## スクリーンショット

<!-- Command + Shift + Control + 4 でスクリーンショットして Command + V でここに貼り付けるのが楽。録画動画があればなお良い。以下のテーブルは必要に応じて使ってください -->

|       | Before | After |
| :---: | :----: | :---: |
|  |  |  |


# 影響範囲・懸念点

<!-- レビュアーに見てほしい点、影響しそうな機能 -->
一応修正はしましたが、原因が分からないのでmainへのマージ後に再び同じ症状が起こるかもしれません

# おこなった動作確認

<!-- おこなった動作確認を箇条書きで。 -->
* UEを閉じて再び軌道してもファイルメディアソースが残っているか
* チュートリアルステージを実行確認して動画が再生されているか

# その他

<!-- レビュアーへのメッセージや一言などあれば -->
