### PR TITLE
タスクUI非表示バグ修正

### DIFF
--- a/Content/CaseStudy/Hatta_UIProtOfConceptForAlpha/BluePrint/Copy/WBP_TakeTaskScreenVer2.uasset
+++ b/Content/CaseStudy/Hatta_UIProtOfConceptForAlpha/BluePrint/Copy/WBP_TakeTaskScreenVer2.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c1856ea709cf8bd4d51ca1f2d3d71d2b7375e47bf791384db5a50f3f6c8ee3cf
-size 481175
+oid sha256:377f88b6073a9b6d000747d9d4430edbe5989c66751b3e5bd0cf246a8a76e7a4
+size 483737

--- a/Content/CaseStudy/Yamagucchi_Proto/BP/BP_MaouCamera.uasset
+++ b/Content/CaseStudy/Yamagucchi_Proto/BP/BP_MaouCamera.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:532fa63e00bd2cce76af1a59e89ec649554ebf030c60a4993dbdba6c36188d0e
-size 639118
+oid sha256:cdff660d320de14d107ecbe9a14e35b857cac92220634afcea4eec4c9508a0df
+size 637483


### PR DESCRIPTION
# 概要



# 細かな変更点

<!-- コード自体の変更についてサマリを記載する。レビュアーが「なんで概要に書かれていないこれが変更されたんだろう？」と思わないように説明するのがポイント -->

- ゲームクリアのフラグが立っている状態で、タスク受注ウィンドウを開いたままスクショを取るとウィンドウが画面に残ったままになる不具合を修正
- タスク受注ウィンドウを開いたままスクショを取ると、撮影のエフェクトよりも手前にウィンドウが描画されてしまう不具合を修正

## スクリーンショット

<!-- Command + Shift + Control + 4 でスクリーンショットして Command + V でここに貼り付けるのが楽。録画動画があればなお良い。以下のテーブルは必要に応じて使ってください -->

| Summary | Before | After |
| :---: | :----: | :---: |
| 魔王カメラ変更箇所 |  | <img width="637" height="413" alt="スクリーンショット 2025-07-18 154849" src="https://github.com/user-attachments/assets/84c36f0f-98bd-4f31-a620-00c9f8d00b5a" /> |
| タスク受注ウィンドウ変更箇所 |  | <img width="681" height="553" alt="スクリーンショット 2025-07-18 154832" src="https://github.com/user-attachments/assets/d9280c89-d026-4e8a-97b7-58ac8784fb37" /> |

# 影響範囲・懸念点

<!-- レビュアーに見てほしい点、影響しそうな機能 -->


# おこなった動作確認

<!-- おこなった動作確認を箇条書きで。 -->
* [ウィンドウを開いている状態でスクショを撮影し、エフェクトが最前面に出ているか確認]
* ウィンドウを開いている状態でステージをクリアし、ウィンドウが連動して消えているか確認 


# その他

<!-- レビュアーへのメッセージや一言などあれば -->
